### PR TITLE
Added GetLayerByName method to retrieve a TileLayer by its name

### DIFF
--- a/GameEngine/Tiled/TiledMap.cs
+++ b/GameEngine/Tiled/TiledMap.cs
@@ -269,6 +269,11 @@ namespace GameEngine.Tiled
             return map;
         }
 
+        public TileLayer GetLayerByName(string name)
+        {
+            return TileLayers.Find(delegate(TileLayer t) { return t.Name.Equals(name); });
+        }
+
         public override string ToString()
         {
             return string.Format("TiledMap: Dimensions={0}x{1}, TileDimensions={2}x{3}, TileLayers={4}, ObjectLayers={5}",


### PR DESCRIPTION
Provides a fix for issue #6
